### PR TITLE
Simplify driver API

### DIFF
--- a/DRIVER-API.md
+++ b/DRIVER-API.md
@@ -110,10 +110,6 @@ Returning an array of cells for each row, along with a separate "columns" array,
 
 However, many current SQLite bindings do not expose the raw array calls. Even if they do, this path may be slower than using objects from the start. Since using the results as an array is quite rare in practice, this is left as an optional configuration, rather than a requirement for the all queries.
 
-### Separate bind/step/reset
-
-This allows a lot of flexibility, for example partial rebinding of parameters instead of specifying all parameters each time a prepared statement is used. However, those type of use cases are rare, and this is not important in the overall architecture. These could all be combined into a single "query with parameters" call, but would need to take into account optional streaming of results.
-
 ### bigint
 
 SQLite supports up to 8-byte signed integers (up to 2^64-1), while JavaScript's number is limited to 2^53-1. General approaches include:

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -1,4 +1,4 @@
-import { SqliteArguments, SqliteRowObject } from '@sqlite-js/driver';
+import { SqliteArguments, SqliteObjectRow } from '@sqlite-js/driver';
 
 export type SqliteDatabase = SqliteConnectionPool & SqliteConnection;
 
@@ -61,7 +61,7 @@ export interface ReservedSqliteConnection extends SqliteConnection {
 }
 
 export interface QueryInterface {
-  prepare<T extends SqliteRowObject>(
+  prepare<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: QueryOptions
@@ -73,7 +73,7 @@ export interface QueryInterface {
     options?: ReserveConnectionOptions
   ): Promise<RunResult>;
 
-  stream<T extends SqliteRowObject>(
+  stream<T extends SqliteObjectRow>(
     query: string,
     args: SqliteArguments,
     options?: StreamOptions & ReserveConnectionOptions
@@ -84,7 +84,7 @@ export interface QueryInterface {
    *
    * When called on a connection pool, uses readonly: true by default.
    */
-  select<T extends SqliteRowObject>(
+  select<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: QueryOptions & ReserveConnectionOptions
@@ -99,7 +99,7 @@ export interface QueryInterface {
    * @param args
    * @param options
    */
-  get<T extends SqliteRowObject>(
+  get<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: QueryOptions & ReserveConnectionOptions
@@ -114,7 +114,7 @@ export interface QueryInterface {
    * @param args
    * @param options
    */
-  getOptional<T extends SqliteRowObject>(
+  getOptional<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: QueryOptions & ReserveConnectionOptions
@@ -236,7 +236,7 @@ export interface RunResult {
   lastInsertRowId: bigint;
 }
 
-export interface PreparedQuery<T extends SqliteRowObject> {
+export interface PreparedQuery<T extends SqliteObjectRow> {
   parse(): Promise<{ columns: string[] }>;
 
   /**

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -61,11 +61,7 @@ export interface ReservedSqliteConnection extends SqliteConnection {
 }
 
 export interface QueryInterface {
-  prepare<T extends SqliteObjectRow>(
-    query: string,
-    args?: SqliteArguments,
-    options?: QueryOptions
-  ): PreparedQuery<T>;
+  prepare<T extends SqliteObjectRow>(query: string): PreparedQuery<T>;
 
   run(
     query: string,

--- a/packages/api/src/impl.ts
+++ b/packages/api/src/impl.ts
@@ -26,7 +26,7 @@ import {
   SqliteDriverConnection,
   SqliteDriverConnectionPool,
   SqliteDriverStatement,
-  SqliteRowObject
+  SqliteObjectRow
 } from '@sqlite-js/driver';
 
 export class ConnectionPoolImpl
@@ -54,7 +54,7 @@ export class ConnectionPoolImpl
     throw new Error('Method not implemented.');
   }
 
-  prepare<T extends SqliteRowObject>(
+  prepare<T extends SqliteObjectRow>(
     sql: string,
     args?: SqliteArguments
   ): PreparedQuery<T> {
@@ -103,7 +103,7 @@ export class ConnectionPoolImpl
     return tx;
   }
 
-  async *stream<T extends SqliteRowObject>(
+  async *stream<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: (StreamOptions & ReserveConnectionOptions) | undefined
@@ -116,7 +116,7 @@ export class ConnectionPoolImpl
     }
   }
 
-  async select<T extends SqliteRowObject>(
+  async select<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments | undefined,
     options?: (QueryOptions & ReserveConnectionOptions) | undefined
@@ -129,7 +129,7 @@ export class ConnectionPoolImpl
     }
   }
 
-  async get<T extends SqliteRowObject>(
+  async get<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments | undefined,
     options?: (QueryOptions & ReserveConnectionOptions) | undefined
@@ -142,7 +142,7 @@ export class ConnectionPoolImpl
     }
   }
 
-  async getOptional<T extends SqliteRowObject>(
+  async getOptional<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments | undefined,
     options?: (QueryOptions & ReserveConnectionOptions) | undefined
@@ -202,7 +202,7 @@ export class ReservedConnectionImpl implements ReservedSqliteConnection {
     }
   }
 
-  prepare<T extends SqliteRowObject>(
+  prepare<T extends SqliteObjectRow>(
     sql: string,
     args?: SqliteArguments,
     options?: QueryOptions
@@ -252,7 +252,7 @@ export class ReservedConnectionImpl implements ReservedSqliteConnection {
     return this.connection.run(query, args);
   }
 
-  stream<T extends SqliteRowObject>(
+  stream<T extends SqliteObjectRow>(
     query: string,
     args: SqliteArguments | undefined,
     options?: StreamOptions | undefined
@@ -260,7 +260,7 @@ export class ReservedConnectionImpl implements ReservedSqliteConnection {
     return this.connection.stream(query, args, options);
   }
 
-  select<T extends SqliteRowObject>(
+  select<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments | undefined,
     options?: QueryOptions | undefined
@@ -268,7 +268,7 @@ export class ReservedConnectionImpl implements ReservedSqliteConnection {
     return this.connection.select(query, args, options);
   }
 
-  get<T extends SqliteRowObject>(
+  get<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: QueryOptions
@@ -276,7 +276,7 @@ export class ReservedConnectionImpl implements ReservedSqliteConnection {
     return this.connection.get(query, args, options);
   }
 
-  getOptional<T extends SqliteRowObject>(
+  getOptional<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: QueryOptions
@@ -295,11 +295,13 @@ export class ConnectionImpl implements SqliteConnection {
 
   private init() {
     this._beginExclusive ??= this.prepare('BEGIN EXCLUSIVE', undefined, {
-      persist: true
+      autoFinalize: true
     });
-    this._begin ??= this.prepare('BEGIN', undefined, { persist: true });
-    this.commit ??= this.prepare('COMMIT', undefined, { persist: true });
-    this.rollback ??= this.prepare('ROLLBACK', undefined, { persist: true });
+    this._begin ??= this.prepare('BEGIN', undefined, { autoFinalize: true });
+    this.commit ??= this.prepare('COMMIT', undefined, { autoFinalize: true });
+    this.rollback ??= this.prepare('ROLLBACK', undefined, {
+      autoFinalize: true
+    });
   }
 
   async begin(options?: TransactionOptions): Promise<SqliteBeginTransaction> {
@@ -362,7 +364,7 @@ export class ConnectionImpl implements SqliteConnection {
     this.rollback?.dispose();
   }
 
-  prepare<T extends SqliteRowObject>(
+  prepare<T extends SqliteObjectRow>(
     sql: string,
     args?: SqliteArguments,
     options?: PrepareOptions
@@ -392,7 +394,7 @@ export class ConnectionImpl implements SqliteConnection {
     return await statement.run();
   }
 
-  async *stream<T extends SqliteRowObject>(
+  async *stream<T extends SqliteObjectRow>(
     query: string | PreparedQuery<T>,
     args: SqliteArguments | undefined,
     options?: StreamOptions | undefined
@@ -416,7 +418,7 @@ export class ConnectionImpl implements SqliteConnection {
     }
   }
 
-  async select<T extends SqliteRowObject>(
+  async select<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: (QueryOptions & ReserveConnectionOptions) | undefined
@@ -432,7 +434,7 @@ export class ConnectionImpl implements SqliteConnection {
     return rows as T[];
   }
 
-  async get<T extends SqliteRowObject>(
+  async get<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: (QueryOptions & ReserveConnectionOptions) | undefined
@@ -444,7 +446,7 @@ export class ConnectionImpl implements SqliteConnection {
     return row;
   }
 
-  async getOptional<T extends SqliteRowObject>(
+  async getOptional<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: (QueryOptions & ReserveConnectionOptions) | undefined
@@ -467,7 +469,7 @@ export class TransactionImpl implements SqliteTransaction {
     await this.con.rollback!.select();
   }
 
-  prepare<T extends SqliteRowObject>(
+  prepare<T extends SqliteObjectRow>(
     sql: string,
     args?: SqliteArguments,
     options?: QueryOptions
@@ -486,7 +488,7 @@ export class TransactionImpl implements SqliteTransaction {
     return this.con.run(query, args);
   }
 
-  stream<T extends SqliteRowObject>(
+  stream<T extends SqliteObjectRow>(
     query: string,
     args: SqliteArguments,
     options?: StreamOptions | undefined
@@ -494,7 +496,7 @@ export class TransactionImpl implements SqliteTransaction {
     return this.con.stream(query, args, options);
   }
 
-  select<T extends SqliteRowObject>(
+  select<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: QueryOptions | undefined
@@ -502,7 +504,7 @@ export class TransactionImpl implements SqliteTransaction {
     return this.con.select(query, args, options);
   }
 
-  get<T extends SqliteRowObject>(
+  get<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: QueryOptions | undefined
@@ -510,7 +512,7 @@ export class TransactionImpl implements SqliteTransaction {
     return this.con.get(query, args, options);
   }
 
-  getOptional<T extends SqliteRowObject>(
+  getOptional<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: QueryOptions | undefined
@@ -556,7 +558,7 @@ class BeginTransactionImpl
     }
   }
 
-  async select<T extends SqliteRowObject>(
+  async select<T extends SqliteObjectRow>(
     query: string,
     args?: SqliteArguments,
     options?: (QueryOptions & ReserveConnectionOptions) | undefined
@@ -590,7 +592,7 @@ class BeginTransactionImpl
   }
 }
 
-class ConnectionPoolPreparedQueryImpl<T extends SqliteRowObject>
+class ConnectionPoolPreparedQueryImpl<T extends SqliteObjectRow>
   implements PreparedQuery<T>
 {
   [Symbol.dispose]: () => void = undefined as any;
@@ -668,7 +670,7 @@ class ConnectionPoolPreparedQueryImpl<T extends SqliteRowObject>
   }
 }
 
-class ConnectionPreparedQueryImpl<T extends SqliteRowObject>
+class ConnectionPreparedQueryImpl<T extends SqliteObjectRow>
   implements PreparedQuery<T>
 {
   [Symbol.dispose]: () => void = undefined as any;

--- a/packages/better-sqlite3-driver/src/sync-driver.ts
+++ b/packages/better-sqlite3-driver/src/sync-driver.ts
@@ -1,13 +1,14 @@
 import {
   PrepareOptions,
-  ResetOptions,
+  QueryOptions,
+  SqliteArrayRow,
   SqliteChanges,
   SqliteDriverConnection,
   SqliteDriverStatement,
+  SqliteObjectRow,
   SqliteParameterBinding,
-  SqliteStepResult,
   SqliteValue,
-  StepOptions,
+  StreamQueryOptions,
   UpdateListener
 } from '@sqlite-js/driver';
 import type * as bsqlite from 'better-sqlite3';
@@ -23,11 +24,6 @@ interface InternalStatement extends SqliteDriverStatement {
 
 class BetterSqlitePreparedStatement implements InternalStatement {
   public statement: bsqlite.Statement;
-  private options: PrepareOptions;
-  private bindPositional: SqliteValue[] = [];
-  private bindNamed: Record<string, SqliteValue> = {};
-  private statementDone = false;
-  private iterator: Iterator<unknown> | undefined = undefined;
 
   readonly persisted: boolean;
 
@@ -35,7 +31,6 @@ class BetterSqlitePreparedStatement implements InternalStatement {
 
   constructor(statement: bsqlite.Statement, options: PrepareOptions) {
     this.statement = statement;
-    this.options = options;
     this.persisted = options.autoFinalize ?? false;
 
     if (typeof Symbol.dispose != 'undefined') {
@@ -57,140 +52,125 @@ class BetterSqlitePreparedStatement implements InternalStatement {
     }
   }
 
-  bind(parameters: SqliteParameterBinding): void {
-    if (parameters == null) {
-      return;
-    }
-    if (Array.isArray(parameters)) {
-      let bindArray = this.bindPositional;
-
-      for (let i = 0; i < parameters.length; i++) {
-        if (typeof parameters[i] != 'undefined') {
-          bindArray[i] = parameters[i]!;
-        }
-      }
-    } else {
-      for (let key in parameters) {
-        const value = parameters[key];
-        let name = key;
-        const prefix = key[0];
-        // better-sqlite doesn't support the explicit prefix - strip it
-        if (prefix == ':' || prefix == '?' || prefix == '$' || prefix == '@') {
-          name = key.substring(1);
-        }
-        this.bindNamed[name] = value;
-      }
-    }
-  }
-
-  async step(n?: number, options?: StepOptions): Promise<SqliteStepResult> {
-    try {
-      return this.stepSync(n, options);
-    } catch (e) {
-      throw mapError(e);
-    }
-  }
-
-  async run(options?: StepOptions): Promise<SqliteChanges> {
-    try {
-      return this.runSync(options);
-    } catch (e) {
-      throw mapError(e);
-    }
-  }
-
-  runSync(options?: StepOptions): SqliteChanges {
+  private checkTransaction(options: QueryOptions | undefined) {
     if (options?.requireTransaction) {
       if (!this.statement.database.inTransaction) {
         throw new Error('Transaction has been rolled back');
       }
     }
+  }
+
+  _all(
+    parameters: SqliteParameterBinding,
+    options: QueryOptions | undefined,
+    array: boolean
+  ): unknown[] {
+    this.checkTransaction(options);
 
     const statement = this.statement;
-    this.reset();
 
+    statement.safeIntegers(options?.bigint ?? false);
+    statement.raw(array);
+    const r = statement.all(sanitizeParameters(parameters));
+    return r;
+  }
+
+  async all(
+    parameters?: SqliteParameterBinding,
+    options?: QueryOptions
+  ): Promise<SqliteObjectRow[]> {
     try {
-      const bindNamed = this.bindNamed;
-      const bindPositional = this.bindPositional;
-      const bind = [bindPositional, bindNamed].filter((b) => b != null);
-
-      statement.safeIntegers(true);
-      const r = statement.run(...bind);
-      return {
-        changes: r.changes,
-        lastInsertRowId: r.lastInsertRowid as bigint
-      };
-    } finally {
-      this.reset();
+      return this._all(parameters, options, false) as SqliteObjectRow[];
+    } catch (e) {
+      throw mapError(e);
     }
   }
 
-  stepSync(n?: number, options?: StepOptions): SqliteStepResult {
-    const all = n == null;
+  async allArray(
+    parameters?: SqliteParameterBinding,
+    options?: QueryOptions
+  ): Promise<SqliteArrayRow[]> {
+    try {
+      return this._all(parameters, options, true) as SqliteArrayRow[];
+    } catch (e) {
+      throw mapError(e);
+    }
+  }
+
+  *_stream(
+    parameters: SqliteParameterBinding,
+    options: StreamQueryOptions | undefined,
+    array: boolean
+  ) {
+    this.checkTransaction(options);
 
     const statement = this.statement;
-    if (this.statementDone) {
-      return { done: true } as SqliteStepResult;
-    }
 
-    if (options?.requireTransaction) {
-      if (!this.statement.database.inTransaction) {
-        throw new Error('Transaction has been rolled back');
+    statement.safeIntegers(options?.bigint ?? false);
+    statement.raw(array);
+    const iter = statement.iterate(sanitizeParameters(parameters));
+    const maxBuffer = options?.chunkMaxRows ?? 100;
+    let buffer: any[] = [];
+    for (let row of iter) {
+      buffer.push(row as any);
+      if (buffer.length >= maxBuffer) {
+        yield buffer;
+        buffer = [];
       }
     }
+  }
 
-    const bindNamed = this.bindNamed;
-    const bindPositional = this.bindPositional;
-    const bind = [bindPositional, bindNamed].filter((b) => b != null);
-    if (!statement.reader) {
-      statement.run(...bind);
-      this.statementDone = true;
-      return { rows: [], done: true } as SqliteStepResult;
+  async *stream(
+    parameters?: SqliteParameterBinding,
+    options?: StreamQueryOptions
+  ): AsyncIterator<SqliteObjectRow[]> {
+    try {
+      yield* this._stream(parameters, options, false);
+    } catch (e) {
+      throw mapError(e);
     }
-    let iterator = this.iterator;
-    const num_rows = n ?? 1;
-    if (iterator == null) {
-      statement.raw(this.options.rawResults ?? false);
-      statement.safeIntegers(this.options.bigint ?? false);
-      iterator = statement.iterate(...bind);
-      this.iterator = iterator;
+  }
+
+  async *streamArray(
+    parameters?: SqliteParameterBinding,
+    options?: StreamQueryOptions
+  ): AsyncIterator<SqliteArrayRow[]> {
+    try {
+      yield* this._stream(parameters, options, true);
+    } catch (e) {
+      throw mapError(e);
     }
-    let rows = [];
-    let isDone = false;
-    for (let i = 0; i < num_rows || all; i++) {
-      const { value, done } = iterator.next();
-      if (done) {
-        isDone = true;
-        break;
-      }
-      rows.push(value);
+  }
+
+  async run(
+    parameters?: SqliteParameterBinding,
+    options?: QueryOptions
+  ): Promise<SqliteChanges> {
+    try {
+      return this._run(parameters, options);
+    } catch (e) {
+      throw mapError(e);
     }
-    if (isDone) {
-      this.statementDone = true;
-    }
-    return { rows, done: isDone } as SqliteStepResult;
+  }
+
+  _run(
+    parameters: SqliteParameterBinding,
+    options?: QueryOptions
+  ): SqliteChanges {
+    this.checkTransaction(options);
+
+    const statement = this.statement;
+
+    statement.safeIntegers(true);
+    const r = statement.run(sanitizeParameters(parameters));
+    return {
+      changes: r.changes,
+      lastInsertRowId: r.lastInsertRowid as bigint
+    };
   }
 
   finalize(): void {
-    const existingIter = this.iterator;
-    if (existingIter != null) {
-      existingIter.return?.();
-    }
-    this.iterator = undefined;
-    this.statementDone = false;
-  }
-
-  reset(options?: ResetOptions): void {
-    if (this.iterator) {
-      const iter = this.iterator;
-      iter.return!();
-      this.iterator = undefined;
-    }
-    if (options?.clearBindings) {
-      this.bindNamed = {};
-      this.bindPositional = [];
-    }
-    this.statementDone = false;
+    // TODO: cancel iterators
   }
 }
 
@@ -285,4 +265,26 @@ export class BetterSqliteConnection implements SqliteDriverConnection {
     }
     return () => {};
   }
+}
+
+function sanitizeParameters(
+  parameters: SqliteParameterBinding
+): SqliteParameterBinding {
+  if (parameters == null) {
+    return [];
+  } else if (Array.isArray(parameters)) {
+    return parameters;
+  }
+  let result: Record<string, SqliteValue> = {};
+  for (let key in parameters) {
+    const value = parameters[key];
+    let name = key;
+    const prefix = key[0];
+    // better-sqlite doesn't support the explicit prefix - strip it
+    if (prefix == ':' || prefix == '?' || prefix == '$' || prefix == '@') {
+      name = key.substring(1);
+    }
+    result[name] = value;
+  }
+  return result;
 }

--- a/packages/better-sqlite3-driver/src/sync-driver.ts
+++ b/packages/better-sqlite3-driver/src/sync-driver.ts
@@ -36,7 +36,7 @@ class BetterSqlitePreparedStatement implements InternalStatement {
   constructor(statement: bsqlite.Statement, options: PrepareOptions) {
     this.statement = statement;
     this.options = options;
-    this.persisted = options.persist ?? false;
+    this.persisted = options.autoFinalize ?? false;
 
     if (typeof Symbol.dispose != 'undefined') {
       this[Symbol.dispose] = () => this.finalize();

--- a/packages/driver/src/driver-api.ts
+++ b/packages/driver/src/driver-api.ts
@@ -61,11 +61,11 @@ export interface SqliteDriverStatement {
   stream(
     parameters?: SqliteParameterBinding,
     options?: StreamQueryOptions
-  ): AsyncIterator<SqliteObjectRow[]>;
+  ): AsyncIterableIterator<SqliteObjectRow[]>;
   streamArray(
     parameters?: SqliteParameterBinding,
     options?: StreamQueryOptions
-  ): AsyncIterator<SqliteArrayRow[]>;
+  ): AsyncIterableIterator<SqliteArrayRow[]>;
 
   /**
    * Run a query, and return the number of changed rows, and last insert id.

--- a/packages/driver/src/driver-api.ts
+++ b/packages/driver/src/driver-api.ts
@@ -54,7 +54,7 @@ export interface SqliteDriverStatement {
     options?: QueryOptions
   ): Promise<SqliteObjectRow[]>;
   allArray(
-    parameters: SqliteParameterBinding,
+    parameters?: SqliteParameterBinding,
     options?: QueryOptions
   ): Promise<SqliteArrayRow[]>;
 

--- a/packages/driver/src/driver-api.ts
+++ b/packages/driver/src/driver-api.ts
@@ -12,10 +12,6 @@ export interface PrepareOptions {
   autoFinalize?: boolean;
 }
 
-export interface ResetOptions {
-  clearBindings?: boolean;
-}
-
 export interface SqliteDriverConnection {
   /**
    * Prepare a statement.
@@ -49,19 +45,43 @@ export interface StreamQueryOptions extends QueryOptions {
 }
 
 export interface SqliteDriverStatement {
+  /**
+   * Run a query, and return results as an array of row objects.
+   *
+   * If the query does not return results, an empty array is returned.
+   */
   all(
     parameters?: SqliteParameterBinding,
     options?: QueryOptions
   ): Promise<SqliteObjectRow[]>;
+
+  /**
+   * Run a query, and return results as an array of row arrays.
+   *
+   * If the query does not return results, an empty array is returned.
+   */
   allArray(
     parameters?: SqliteParameterBinding,
     options?: QueryOptions
   ): Promise<SqliteArrayRow[]>;
 
+  /**
+   * Run a query, and return as an iterator of array of row object chunks.
+   *
+   * It is an error to call any other query methods on the same statement
+   * before the iterator has returned.
+   */
   stream(
     parameters?: SqliteParameterBinding,
     options?: StreamQueryOptions
   ): AsyncIterableIterator<SqliteObjectRow[]>;
+
+  /**
+   * Run a query, and return as an iterator of array of row array chunks.
+   *
+   * It is an error to call any other query methods on the same statement
+   * before the iterator has returned.
+   */
   streamArray(
     parameters?: SqliteParameterBinding,
     options?: StreamQueryOptions
@@ -75,6 +95,9 @@ export interface SqliteDriverStatement {
     options?: QueryOptions
   ): Promise<SqliteChanges>;
 
+  /**
+   * Get the column names of the data returned by the query.
+   */
   getColumns(): Promise<string[]>;
 
   finalize(): void;
@@ -86,7 +109,6 @@ export interface SqliteDriverConnectionPool {
    * Reserve a connection for exclusive use.
    *
    * If there is no available connection, this will wait until one is available.
-   * @param options
    */
   reserveConnection(
     options?: ReserveConnectionOptions

--- a/packages/driver/src/node/impl.ts
+++ b/packages/driver/src/node/impl.ts
@@ -187,7 +187,9 @@ export class NodeSqliteConnection implements SqliteDriverConnection {
 }
 
 function convertParameters(parameters: SqliteParameterBinding): any[] {
-  if (Array.isArray(parameters)) {
+  if (parameters == null) {
+    return [];
+  } else if (Array.isArray(parameters)) {
     return parameters;
   } else {
     return [parameters];

--- a/packages/driver/src/node/impl.ts
+++ b/packages/driver/src/node/impl.ts
@@ -114,7 +114,7 @@ class NodeSqliteSyncStatement implements InternalStatement {
   async *stream(
     parameters: SqliteParameterBinding,
     options: StreamQueryOptions
-  ): AsyncIterator<SqliteObjectRow[]> {
+  ): AsyncIterableIterator<SqliteObjectRow[]> {
     const rows = await this.all(parameters, options);
     yield rows;
   }
@@ -122,7 +122,7 @@ class NodeSqliteSyncStatement implements InternalStatement {
   streamArray(
     parameters: SqliteParameterBinding,
     options: StreamQueryOptions
-  ): AsyncIterator<SqliteArrayRow[]> {
+  ): AsyncIterableIterator<SqliteArrayRow[]> {
     throw new Error('array rows are not supported');
   }
 

--- a/packages/driver/src/util/ErrorStatement.ts
+++ b/packages/driver/src/util/ErrorStatement.ts
@@ -31,25 +31,25 @@ export class ErrorStatement implements SqliteDriverStatement {
     this.persisted = options.autoFinalize ?? false;
   }
 
-  all(
+  async all(
     parameters: SqliteParameterBinding,
     options: QueryOptions
   ): Promise<SqliteObjectRow[]> {
     throw this.error;
   }
-  allArray(
+  async allArray(
     parameters: SqliteParameterBinding,
     options: QueryOptions
   ): Promise<SqliteArrayRow[]> {
     throw this.error;
   }
-  stream(
+  async *stream(
     parameters: SqliteParameterBinding,
     options: StreamQueryOptions
   ): AsyncIterator<SqliteObjectRow[]> {
     throw this.error;
   }
-  streamArray(
+  async *streamArray(
     parameters: SqliteParameterBinding,
     options: StreamQueryOptions
   ): AsyncIterator<SqliteArrayRow[]> {

--- a/packages/driver/src/util/ErrorStatement.ts
+++ b/packages/driver/src/util/ErrorStatement.ts
@@ -46,13 +46,13 @@ export class ErrorStatement implements SqliteDriverStatement {
   async *stream(
     parameters: SqliteParameterBinding,
     options: StreamQueryOptions
-  ): AsyncIterator<SqliteObjectRow[]> {
+  ): AsyncIterableIterator<SqliteObjectRow[]> {
     throw this.error;
   }
   async *streamArray(
     parameters: SqliteParameterBinding,
     options: StreamQueryOptions
-  ): AsyncIterator<SqliteArrayRow[]> {
+  ): AsyncIterableIterator<SqliteArrayRow[]> {
     throw this.error;
   }
 

--- a/packages/driver/src/util/ErrorStatement.ts
+++ b/packages/driver/src/util/ErrorStatement.ts
@@ -1,11 +1,12 @@
 import {
   PrepareOptions,
-  ResetOptions,
+  QueryOptions,
+  SqliteArrayRow,
   SqliteChanges,
   SqliteDriverStatement,
+  SqliteObjectRow,
   SqliteParameterBinding,
-  SqliteStepResult,
-  StepOptions
+  StreamQueryOptions
 } from '../driver-api.js';
 import { SqliteDriverError } from '../worker_threads/async-commands.js';
 
@@ -27,28 +28,45 @@ export class ErrorStatement implements SqliteDriverStatement {
   ) {
     this.error = error;
     this.source = source;
-    this.persisted = options.persist ?? false;
+    this.persisted = options.autoFinalize ?? false;
+  }
+
+  all(
+    parameters: SqliteParameterBinding,
+    options: QueryOptions
+  ): Promise<SqliteObjectRow[]> {
+    throw this.error;
+  }
+  allArray(
+    parameters: SqliteParameterBinding,
+    options: QueryOptions
+  ): Promise<SqliteArrayRow[]> {
+    throw this.error;
+  }
+  stream(
+    parameters: SqliteParameterBinding,
+    options: StreamQueryOptions
+  ): AsyncIterator<SqliteObjectRow[]> {
+    throw this.error;
+  }
+  streamArray(
+    parameters: SqliteParameterBinding,
+    options: StreamQueryOptions
+  ): AsyncIterator<SqliteArrayRow[]> {
+    throw this.error;
   }
 
   async getColumns(): Promise<string[]> {
     throw this.error;
   }
-  bind(parameters: SqliteParameterBinding): void {
-    // no-op
-  }
-  async step(n?: number, options?: StepOptions): Promise<SqliteStepResult> {
-    throw this.error;
-  }
-
-  async run(options?: StepOptions): Promise<SqliteChanges> {
+  async run(
+    parameters: SqliteParameterBinding,
+    options?: QueryOptions
+  ): Promise<SqliteChanges> {
     throw this.error;
   }
 
   finalize(): void {
-    // no-op
-  }
-
-  reset(options?: ResetOptions): void {
     // no-op
   }
 

--- a/packages/driver/src/worker_threads/worker-driver.ts
+++ b/packages/driver/src/worker_threads/worker-driver.ts
@@ -1,16 +1,15 @@
 import * as worker_threads from 'worker_threads';
 import {
   PrepareOptions,
-  ResetOptions,
-  SqliteDriverConnection,
-  SqliteDriverStatement,
-  SqliteParameterBinding,
-  SqliteChanges,
-  UpdateListener,
   QueryOptions,
   SqliteArrayRow,
+  SqliteChanges,
+  SqliteDriverConnection,
+  SqliteDriverStatement,
   SqliteObjectRow,
-  StreamQueryOptions
+  SqliteParameterBinding,
+  StreamQueryOptions,
+  UpdateListener
 } from '../driver-api.js';
 
 import { Deferred } from '../deferred.js';

--- a/packages/driver/src/worker_threads/worker-driver.ts
+++ b/packages/driver/src/worker_threads/worker-driver.ts
@@ -226,14 +226,14 @@ class WorkerDriverStatement implements SqliteDriverStatement {
   stream(
     parameters: SqliteParameterBinding,
     options?: StreamQueryOptions
-  ): AsyncIterator<SqliteObjectRow[]> {
+  ): AsyncIterableIterator<SqliteObjectRow[]> {
     throw new Error('Method not implemented.');
   }
 
   streamArray(
     parameters: SqliteParameterBinding,
     options?: StreamQueryOptions
-  ): AsyncIterator<SqliteArrayRow[]> {
+  ): AsyncIterableIterator<SqliteArrayRow[]> {
     throw new Error('Method not implemented.');
   }
 

--- a/packages/driver/src/worker_threads/worker-driver.ts
+++ b/packages/driver/src/worker_threads/worker-driver.ts
@@ -6,9 +6,11 @@ import {
   SqliteDriverStatement,
   SqliteParameterBinding,
   SqliteChanges,
-  SqliteStepResult,
-  StepOptions,
-  UpdateListener
+  UpdateListener,
+  QueryOptions,
+  SqliteArrayRow,
+  SqliteObjectRow,
+  StreamQueryOptions
 } from '../driver-api.js';
 
 import { Deferred } from '../deferred.js';
@@ -78,25 +80,11 @@ export class WorkerDriverConnection implements SqliteDriverConnection {
       cmd: {
         type: SqliteCommandType.prepare,
         id,
-        bigint: options?.bigint,
-        persist: options?.persist,
-        rawResults: options?.rawResults,
+        autoFinalize: options?.autoFinalize,
         sql
       }
     });
     return new WorkerDriverStatement(this, id);
-  }
-
-  async getLastChanges(): Promise<SqliteChanges> {
-    return await this._push({
-      type: SqliteCommandType.changes
-    });
-  }
-
-  async sync(): Promise<void> {
-    await this._push({
-      type: SqliteCommandType.sync
-    });
   }
 
   _push<T extends SqliteCommand>(cmd: T): Promise<InferCommandResult<T>> {
@@ -206,6 +194,48 @@ class WorkerDriverStatement implements SqliteDriverStatement {
       this[Symbol.dispose] = () => this.finalize();
     }
   }
+  all(
+    parameters: SqliteParameterBinding,
+    options?: QueryOptions
+  ): Promise<SqliteObjectRow[]> {
+    return this.driver
+      ._push({
+        type: SqliteCommandType.query,
+        id: this.id,
+        parameters: parameters,
+        options: options
+      })
+      .then((r) => r.rows as SqliteObjectRow[]);
+  }
+
+  allArray(
+    parameters: SqliteParameterBinding,
+    options?: QueryOptions
+  ): Promise<SqliteArrayRow[]> {
+    return this.driver
+      ._push({
+        type: SqliteCommandType.query,
+        id: this.id,
+        parameters: parameters,
+        options: options,
+        array: true
+      })
+      .then((r) => r.rows as SqliteArrayRow[]);
+  }
+
+  stream(
+    parameters: SqliteParameterBinding,
+    options?: StreamQueryOptions
+  ): AsyncIterator<SqliteObjectRow[]> {
+    throw new Error('Method not implemented.');
+  }
+
+  streamArray(
+    parameters: SqliteParameterBinding,
+    options?: StreamQueryOptions
+  ): AsyncIterator<SqliteArrayRow[]> {
+    throw new Error('Method not implemented.');
+  }
 
   async getColumns(): Promise<string[]> {
     return this.driver
@@ -216,28 +246,15 @@ class WorkerDriverStatement implements SqliteDriverStatement {
       .then((r) => r.columns);
   }
 
-  bind(parameters: SqliteParameterBinding): void {
-    this.driver._send({
-      type: SqliteCommandType.bind,
-      id: this.id,
-      parameters: parameters
-    });
-  }
-
-  async step(n?: number, options?: StepOptions): Promise<SqliteStepResult> {
-    return this.driver._push({
-      type: SqliteCommandType.step,
-      id: this.id,
-      n: n,
-      requireTransaction: options?.requireTransaction
-    });
-  }
-
-  async run(options?: StepOptions): Promise<SqliteChanges> {
+  async run(
+    parameters?: SqliteParameterBinding,
+    options?: QueryOptions
+  ): Promise<SqliteChanges> {
     return this.driver._push({
       type: SqliteCommandType.run,
       id: this.id,
-      requireTransaction: options?.requireTransaction
+      parameters: parameters,
+      options: options
     });
   }
 
@@ -245,14 +262,6 @@ class WorkerDriverStatement implements SqliteDriverStatement {
     this.driver._send({
       type: SqliteCommandType.finalize,
       id: this.id
-    });
-  }
-
-  reset(options?: ResetOptions): void {
-    this.driver._send({
-      type: SqliteCommandType.reset,
-      id: this.id,
-      clearBindings: options?.clearBindings
     });
   }
 }


### PR DESCRIPTION
The new PreparedStatement interface is listed below. See discussion in https://github.com/halvardssm/deno_stdext/pull/6 for some background.

This avoids the need for separate bind/step/reset calls. Instead, statements now just take a single call to either return all results, or an iterator of result chunks.

Additionally, this splits out query methods into separate calls for object rows vs array rows.

This simplifies the driver API enough that it can be used directly by client code, versus the previous iteration that felt like you absolutely _need_ a wrapping API.

This loses some flexibility:
1. You now have to specify query parameters each time you run the query, you cannot just bind once and run multiple times.
2. You cannot combine array parameters with named parameters in a single query anymore.

Those were not likely to be real use cases anyway, and the underlying drivers typically did not support those properly either.

This now also moves some options from the prepare call to the query call, so you can use the same prepared statement with different options. 

TODO:
 * [ ] Proper error on concurrent querying on the same prepared statement.
 * [ ] Implement streaming iterators via worker_threads.
 * [ ] Add tests for streaming iterators.

```ts
export interface SqliteDriverStatement {
  /**
   * Run a query, and return results as an array of row objects.
   *
   * If the query does not return results, an empty array is returned.
   */
  all(
    parameters?: SqliteParameterBinding,
    options?: QueryOptions
  ): Promise<SqliteObjectRow[]>;

  /**
   * Run a query, and return results as an array of row arrays.
   *
   * If the query does not return results, an empty array is returned.
   */
  allArray(
    parameters?: SqliteParameterBinding,
    options?: QueryOptions
  ): Promise<SqliteArrayRow[]>;

  /**
   * Run a query, and return as an iterator of array of row object chunks.
   *
   * It is an error to call any other query methods on the same statement
   * before the iterator has returned.
   */
  stream(
    parameters?: SqliteParameterBinding,
    options?: StreamQueryOptions
  ): AsyncIterableIterator<SqliteObjectRow[]>;

  /**
   * Run a query, and return as an iterator of array of row array chunks.
   *
   * It is an error to call any other query methods on the same statement
   * before the iterator has returned.
   */
  streamArray(
    parameters?: SqliteParameterBinding,
    options?: StreamQueryOptions
  ): AsyncIterableIterator<SqliteArrayRow[]>;

  /**
   * Run a query, and return the number of changed rows, and last insert id.
   */
  run(
    parameters?: SqliteParameterBinding,
    options?: QueryOptions
  ): Promise<SqliteChanges>;

  /**
   * Get the column names of the data returned by the query.
   */
  getColumns(): Promise<string[]>;

  finalize(): void;
  [Symbol.dispose](): void;
}
```
